### PR TITLE
Support for ਆਧ ਬਾਣੀ ਸਿਰਲੇਖਾਂ ਦੇ ਪੈਰੀਂ ਅੰਕ, ਦਸਮ ਬਾਣੀ ਦੇ ਹੋਰ ਅੱਧੇ-ਯਯੇ + other misc. chars, rendering fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ All letter conversions at a minimum must address the following letters that are 
 ˜
 †
 æ
+¡
+Å
 0
 1
 2
@@ -208,6 +210,7 @@ I
 Í
 î
 Î
+Ï
 j
 J
 k

--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -32,10 +32,6 @@ describe('unicode', () => {
     expect(unicode('gauVI kbIr jI iqpdy₁₅ ]'))
       .toBe('ਗਉੜੀ ਕਬੀਰ ਜੀ ਤਿਪਦੇ ॥');
 
-    // ਪੈਰ ਅੰਕ combination using two individual glyphs
-    expect(unicode('vw₁₂h vw₄₆h vw₃₄h vwh₆₁'))
-      .toBe('ਵਾਹ ਵਾਹ ਵਾਹ ਵਾਹ');
-
     // ik oangkaar using various char combinations
     expect(unicode('<> siqgur pRswid ]'))
       .toBe('ੴ ਸਤਿਗੁਰ ਪ੍ਰਸਾਦਿ ॥');

--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -20,6 +20,9 @@ describe('unicode', () => {
     expect(unicode('ijgw CqR jVwv kælZI cOr mukqw lwlrI'))
       .toBe('ਜਿਗਾ ਛਤ੍ਰ ਜੜਾਵ ਕ਼ਲਗ਼ੀ ਚੌਰ ਮੁਕਤਾ ਲਾਲਰੀ');
 
+    // Adhik
+    expect(unicode('s`uD ispwh durMq dubwh su swj snwh durjwn dlYNgy ]'))
+      .toBe('ਸੁੱਧ ਸਿਪਾਹ ਦੁਰੰਤ ਦੁਬਾਹ ਸੁ ਸਾਜ ਸਨਾਹ ਦੁਰਜਾਨ ਦਲੈਂਗੇ ॥');
     // MU
     expect(unicode('hMU'))
       .toBe('ਹੂੰ');

--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -32,6 +32,19 @@ describe('unicode', () => {
     expect(unicode('rwgu gauVI pUrbI²1 mhlw 5 ]'))
       .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫ ॥');
 
+    // ik oangkaar using various char combinations
+    expect(unicode('<> siqgur pRswid ]'))
+      .toBe('ੴ ਸਤਿਗੁਰ ਪ੍ਰਸਾਦਿ ॥');
+
+    expect(unicode('1Eå siqgur pRswid ]'))
+      .toBe('ੴ ਸਤਿਗੁਰ ਪ੍ਰਸਾਦਿ ॥');
+
+    expect(unicode('¡ siqgur pRswid ]'))
+      .toBe('ੴ ਸਤਿਗੁਰ ਪ੍ਰਸਾਦਿ ॥');
+
+    expect(unicode('ÅÆ siqgur pRswid ]'))
+      .toBe('ੴ ਸਤਿਗੁਰ ਪ੍ਰਸਾਦਿ ॥');
+
     // MU
     expect(unicode('hUM'))
       .toBe('ਹੂੰ');

--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -21,7 +21,7 @@ describe('unicode', () => {
       .toBe('ਜਿਗਾ ਛਤ੍ਰ ਜੜਾਵ ਕ਼ਲਗ਼ੀ ਚੌਰ ਮੁਕਤਾ ਲਾਲਰੀ');
 
     // Adhik
-    expect(unicode('s`uD ispwh durMq dubwh su swj snwh durjwn dlYNgy ]'))
+    expect(unicode('su`D ispwh durMq dubwh su swj snwh durjwn dlYNgy ]'))
       .toBe('ਸੁੱਧ ਸਿਪਾਹ ਦੁਰੰਤ ਦੁਬਾਹ ਸੁ ਸਾਜ ਸਨਾਹ ਦੁਰਜਾਨ ਦਲੈਂਗੇ ॥');
 
     // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ
@@ -33,7 +33,7 @@ describe('unicode', () => {
       .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫ ॥');
 
     // MU
-    expect(unicode('hMU'))
+    expect(unicode('hUM'))
       .toBe('ਹੂੰ');
 
     // @w

--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -23,6 +23,15 @@ describe('unicode', () => {
     // Adhik
     expect(unicode('s`uD ispwh durMq dubwh su swj snwh durjwn dlYNgy ]'))
       .toBe('ਸੁੱਧ ਸਿਪਾਹ ਦੁਰੰਤ ਦੁਬਾਹ ਸੁ ਸਾਜ ਸਨਾਹ ਦੁਰਜਾਨ ਦਲੈਂਗੇ ॥');
+
+    // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ
+    expect(unicode('rwgu gauVI pUrbI¹1 mhlw 5 ]'))
+      .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫ ॥');
+
+    // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ, shifted right by one char
+    expect(unicode('rwgu gauVI pUrbI²1 mhlw 5 ]'))
+      .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫ ॥');
+
     // MU
     expect(unicode('hMU'))
       .toBe('ਹੂੰ');

--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -24,13 +24,17 @@ describe('unicode', () => {
     expect(unicode('su`D ispwh durMq dubwh su swj snwh durjwn dlYNgy ]'))
       .toBe('ਸੁੱਧ ਸਿਪਾਹ ਦੁਰੰਤ ਦੁਬਾਹ ਸੁ ਸਾਜ ਸਨਾਹ ਦੁਰਜਾਨ ਦਲੈਂਗੇ ॥');
 
-    // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ
-    expect(unicode('rwgu gauVI pUrbI¹1 mhlw 5 ]'))
-      .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫ ॥');
+    // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ ੧
+    expect(unicode('rwgu gauVI pUrbI₁ mhlw 5'))
+      .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫');
 
-    // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ, shifted right by one char
-    expect(unicode('rwgu gauVI pUrbI²1 mhlw 5 ]'))
-      .toBe('ਰਾਗੁ ਗਉੜੀ ਪੂਰਬੀ ਮਹਲਾ ੫ ॥');
+    // ਪੈਰ ਅੰਕ ਸਿਰਲੇਖ ਵਿਚ ੧੫
+    expect(unicode('gauVI kbIr jI iqpdy₁₅ ]'))
+      .toBe('ਗਉੜੀ ਕਬੀਰ ਜੀ ਤਿਪਦੇ ॥');
+
+    // ਪੈਰ ਅੰਕ combination using two individual glyphs
+    expect(unicode('vw₁₂h vw₄₆h vw₃₄h vwh₆₁'))
+      .toBe('ਵਾਹ ਵਾਹ ਵਾਹ ਵਾਹ');
 
     // ik oangkaar using various char combinations
     expect(unicode('<> siqgur pRswid ]'))

--- a/src/translit_modules/devnagri.js
+++ b/src/translit_modules/devnagri.js
@@ -87,6 +87,7 @@ const map = [
   ['¤', '्'], // adhak after letter, use halant to emphasize (replaced below)
   ['´', '्य'], // yakash (pair yaya)
   ['µ', 'ं'], // bindi
+  ['ˆ', 'ं'], // bindi
   ['Í', '्व'], // pair vava
   ['Î', '्य'], // half yaya
   ['Ø', ''], // extra top line (extender)
@@ -147,6 +148,8 @@ module.exports = (gurmukhi) => map.reduce((_str, [gurmukhiLetter, devnagriUnicod
     ['अां', 'आँ'], // अ + ा + ं
     // exception for sihaaree + pair-rarra
     ['ि्र', 'ृ'],
+    // exception for bindi before bihaaree
+    ['ंी', 'ीं'],
     // exceptions for the emphasized (adhik) variants of certain akhars
     ['ख्ख', 'क्ख'],
     ['घ्घ', 'ग्घ'],

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -69,8 +69,8 @@ const mapping = {
   Ï: 'ੵ',
   æ: '਼',
   Î: '੍ਯ',
-  ì: 'ਯੑ', // should render as full yaiya with open top
-  í: '੍ਯੑ', // should render as half yaiya with open top
+  ì: 'ਯ',
+  í: '੍ਯ',
   1: '੧',
   2: '੨',
   3: '੩',

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -101,10 +101,7 @@ const mapping = {
   '₄': '',
   '₅': '',
   '₆': '',
-  '₇': '₇',
   '₈': '',
-  '₉': '₉',
-  '₀': '₀',
   ' ': ' ',
 };
 
@@ -121,16 +118,6 @@ const halfChars = [
   'Î',
   'Ï',
   'í',
-];
-
-const subscriptNumbers = [
-  '₁',
-  '₂',
-  '₃',
-  '₄',
-  '₅',
-  '₆',
-  '₈',
 ];
 
 /**
@@ -239,32 +226,6 @@ function unicode(text = '') {
     } else if (currentChar === '₁' && nextChar === '₅') {
       convertedText += '';
       j += 1;
-    } else if (subscriptNumbers.includes(currentChar)) {
-      convertedText += mapping[currentChar];
-      switch (nextChar) {
-        case '₁':
-          convertedText += '';
-          j += 1;
-          break;
-        case '₂':
-          convertedText += '';
-          j += 1;
-          break;
-        case '₃':
-          convertedText += '';
-          j += 1;
-          break;
-        case '₄':
-          convertedText += '';
-          j += 1;
-          break;
-        case '₆':
-          convertedText += '';
-          j += 1;
-          break;
-        default:
-          break;
-      }
     } else {
       convertedText += mapping[currentChar] || currentChar;
     }

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -100,6 +100,40 @@ const mapping = {
   ' ': ' ',
 };
 
+const halfChars = [
+  'H',
+  'R',
+  '®',
+  'Í',
+  'ç',
+  '†',
+  'œ',
+  '˜',
+  '´',
+  'Î',
+  'Ï',
+  'í',
+];
+
+const subscriptNumbers = {
+  1: '',
+  2: '',
+  3: '',
+  4: '',
+  5: '',
+  6: '',
+  8: '',
+  15: '',
+};
+
+const subscriptNumbersShifted = {
+  1: '',
+  2: '',
+  3: '',
+  4: '',
+  6: '',
+};
+
 /**
  * Convert Gurmukhi script to Unicode
  *
@@ -128,39 +162,6 @@ function unicode(text = '') {
     const currentChar = chars[j];
     const nextChar = chars[j + 1];
     const nextNextChar = chars[j + 2];
-    const halfChars = [
-      'H',
-      'R',
-      '®',
-      'Í',
-      'ç',
-      '†',
-      'œ',
-      '˜',
-      '´',
-      'Î',
-      'Ï',
-      'í',
-    ];
-
-    const subscriptNumbers = {
-      1: '',
-      2: '',
-      3: '',
-      4: '',
-      5: '',
-      6: '',
-      8: '',
-      15: '',
-    };
-
-    const subscriptNumbersShifted = {
-      1: '',
-      2: '',
-      3: '',
-      4: '',
-      6: '',
-    };
 
     if (currentChar === 'i') {
       if (nextChar != null) {
@@ -228,16 +229,6 @@ function unicode(text = '') {
       }
     } else if (currentChar === 'u' && nextChar === 'o') {
       convertedText += 'ੋੁ';
-      j += 1;
-    } else if ((currentChar === 'N' && nextChar === 'I') ||
-    (
-      (currentChar === 'M' || currentChar === 'N' || currentChar === '`' || currentChar === '~') &&
-      (nextChar === 'U' || nextChar === 'u' || nextChar === 'ü')
-    ) ||
-    (currentChar === 'ˆ' && nextChar === 'I') ||
-    (currentChar === 'N' && nextChar === 'y')) {
-      convertedText += mapping[nextChar];
-      convertedText += mapping[currentChar];
       j += 1;
     } else if (currentChar === '¹' && nextChar === '1' && nextNextChar === '5') {
       convertedText += '';

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -66,8 +66,11 @@ const mapping = {
   œ: '੍ਤ',
   '˜': '੍ਨ',
   '´': 'ੵ',
+  Ï: 'ੵ',
   æ: '਼',
   Î: '੍ਯ',
+  ì: 'ਯੑ', // should render as full yaiya with open top
+  í: '੍ਯੑ', // should render as half yaiya with open top
   1: '੧',
   2: '੨',
   3: '੩',
@@ -85,9 +88,13 @@ const mapping = {
   '[': '।',
   ']': '॥',
   '<': 'ੴ',
+  '¡': 'ੴ',
+  Å: 'ੴ',
   Ú: 'ਃ',
+  Ç: '☬',
   '@': 'ੑ',
   '‚': '❁',
+  '•': '𑇇',
   ' ': ' ',
 };
 
@@ -112,21 +119,33 @@ function unicode(text = '') {
   const chars = text
     .replace(/>/gi, '')
     .replace(/Ø/gi, '')
+    .replace(/Æ/g, '')
     .split('');
 
   for (let j = 0; j < chars.length; j += 1) {
     const currentChar = chars[j];
     const nextChar = chars[j + 1];
     const nextNextChar = chars[j + 2];
+    const halfChars = [
+      'H',
+      'R',
+      '®',
+      'Í',
+      'ç',
+      '†',
+      'œ',
+      '˜',
+      '´',
+      'Î',
+      'Ï',
+      'í',
+    ];
 
     if (currentChar === 'i') {
       if (nextChar != null) {
         if (nextChar === 'e') {
           convertedText += 'ਇ';
-        } else if (nextNextChar === 'R' || nextNextChar === 'H' ||
-                            nextNextChar === 'Í' || nextNextChar === 'ç' ||
-                            nextNextChar === '†' || nextNextChar === 'œ' ||
-                            nextNextChar === '~' || nextNextChar === '®') {
+        } else if (halfChars.includes(nextNextChar)) {
           convertedText += mapping[nextChar];
           convertedText += mapping[nextNextChar];
           convertedText += 'ਿ';
@@ -189,7 +208,13 @@ function unicode(text = '') {
     } else if (currentChar === 'u' && nextChar === 'o') {
       convertedText += 'ੋੁ';
       j += 1;
-    } else if ((currentChar === 'N' && nextChar === 'I') || (currentChar === 'M' && (nextChar === 'U' || nextChar === 'u' || nextChar === 'ü')) || (currentChar === 'ˆ' && nextChar === 'I') || (currentChar === 'N' && nextChar === 'y')) {
+    } else if ((currentChar === 'N' && nextChar === 'I') ||
+    (
+      (currentChar === 'M' || currentChar === 'N' || currentChar === '`' || currentChar === '~') &&
+      (nextChar === 'U' || nextChar === 'u' || nextChar === 'ü')
+    ) ||
+    (currentChar === 'ˆ' && nextChar === 'I') ||
+    (currentChar === 'N' && nextChar === 'y')) {
       convertedText += mapping[nextChar];
       convertedText += mapping[currentChar];
       j += 1;

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -95,6 +95,8 @@ const mapping = {
   '@': 'ੑ',
   '‚': '❁',
   '•': '𑇇',
+  '¹': '੍',
+  '²': '੍',
   ' ': ' ',
 };
 
@@ -140,6 +142,25 @@ function unicode(text = '') {
       'Ï',
       'í',
     ];
+
+    const subscriptNumbers = {
+      1: '',
+      2: '',
+      3: '',
+      4: '',
+      5: '',
+      6: '',
+      8: '',
+      15: '',
+    };
+
+    const subscriptNumbersShifted = {
+      1: '',
+      2: '',
+      3: '',
+      4: '',
+      6: '',
+    };
 
     if (currentChar === 'i') {
       if (nextChar != null) {
@@ -217,6 +238,15 @@ function unicode(text = '') {
     (currentChar === 'N' && nextChar === 'y')) {
       convertedText += mapping[nextChar];
       convertedText += mapping[currentChar];
+      j += 1;
+    } else if (currentChar === '¹' && nextChar === '1' && nextNextChar === '5') {
+      convertedText += '';
+      j += 2;
+    } else if (currentChar === '¹') {
+      convertedText += subscriptNumbers[nextChar];
+      j += 1;
+    } else if (currentChar === '²') {
+      convertedText += subscriptNumbersShifted[nextChar];
       j += 1;
     } else {
       convertedText += mapping[currentChar] || currentChar;

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -227,6 +227,9 @@ function unicode(text = '') {
         default:
           convertedText += mapping[currentChar];
       }
+    } else if (currentChar === '1' && nextChar === 'E' && nextNextChar === 'å') {
+      convertedText += 'ੴ';
+      j += 2;
     } else if (currentChar === 'u' && nextChar === 'o') {
       convertedText += 'ੋੁ';
       j += 1;

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -219,10 +219,6 @@ function unicode(text = '') {
     } else if (currentChar === 'u' && nextChar === 'o') {
       convertedText += 'ੋੁ';
       j += 1;
-    } else if (currentChar === 'ˆ' && nextChar === 'I') {
-      convertedText += mapping[nextChar];
-      convertedText += mapping[currentChar];
-      j += 1;
     } else if (currentChar === '₁' && nextChar === '₅') {
       convertedText += '';
       j += 1;

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -95,8 +95,16 @@ const mapping = {
   '@': 'ੑ',
   '‚': '❁',
   '•': '𑇇',
-  '¹': '੍',
-  '²': '੍',
+  '₁': '',
+  '₂': '',
+  '₃': '',
+  '₄': '',
+  '₅': '',
+  '₆': '',
+  '₇': '₇',
+  '₈': '',
+  '₉': '₉',
+  '₀': '₀',
   ' ': ' ',
 };
 
@@ -115,24 +123,15 @@ const halfChars = [
   'í',
 ];
 
-const subscriptNumbers = {
-  1: '',
-  2: '',
-  3: '',
-  4: '',
-  5: '',
-  6: '',
-  8: '',
-  15: '',
-};
-
-const subscriptNumbersShifted = {
-  1: '',
-  2: '',
-  3: '',
-  4: '',
-  6: '',
-};
+const subscriptNumbers = [
+  '₁',
+  '₂',
+  '₃',
+  '₄',
+  '₅',
+  '₆',
+  '₈',
+];
 
 /**
  * Convert Gurmukhi script to Unicode
@@ -237,15 +236,35 @@ function unicode(text = '') {
       convertedText += mapping[nextChar];
       convertedText += mapping[currentChar];
       j += 1;
-    } else if (currentChar === '¹' && nextChar === '1' && nextNextChar === '5') {
+    } else if (currentChar === '₁' && nextChar === '₅') {
       convertedText += '';
-      j += 2;
-    } else if (currentChar === '¹') {
-      convertedText += subscriptNumbers[nextChar];
       j += 1;
-    } else if (currentChar === '²') {
-      convertedText += subscriptNumbersShifted[nextChar];
-      j += 1;
+    } else if (subscriptNumbers.includes(currentChar)) {
+      convertedText += mapping[currentChar];
+      switch (nextChar) {
+        case '₁':
+          convertedText += '';
+          j += 1;
+          break;
+        case '₂':
+          convertedText += '';
+          j += 1;
+          break;
+        case '₃':
+          convertedText += '';
+          j += 1;
+          break;
+        case '₄':
+          convertedText += '';
+          j += 1;
+          break;
+        case '₆':
+          convertedText += '';
+          j += 1;
+          break;
+        default:
+          break;
+      }
     } else {
       convertedText += mapping[currentChar] || currentChar;
     }

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -233,6 +233,10 @@ function unicode(text = '') {
     } else if (currentChar === 'u' && nextChar === 'o') {
       convertedText += 'ੋੁ';
       j += 1;
+    } else if (currentChar === 'ˆ' && nextChar === 'I') {
+      convertedText += mapping[nextChar];
+      convertedText += mapping[currentChar];
+      j += 1;
     } else if (currentChar === '¹' && nextChar === '1' && nextNextChar === '5') {
       convertedText += '';
       j += 2;


### PR DESCRIPTION
Conventions used for ਪੈਰੀਂ ਅੰਕ:

¹ + 1 renders as 
² + 1 renders as  (shifted one char to the right)

Refer to [this Issue](https://github.com/KhalisFoundation/gurmukhi-fonts/issues/2) for rendering examples.