### PR TITLE
simplify characters with embedded lagga matra

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## mainLetters
 
-Removes vowel symbols from a Gurmukhi string
+Removes vowel symbols from a Gurmukhi string.
 
 **Parameters**
 
 -   `words` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The string from which to get main letters
+
+-   `simplify` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to simplify half charactesr to full characters (eg. R to r)
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Retrieve the first letter of each word from a string
 
 -   `words` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The string from which to get first letters
 -   `eng` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the string is English (optional, default `false`)
+-   `simplify` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to simplify embedded vowels/nasal sounds (eg. E to a, ^ to K)
 
 **Examples**
 
@@ -92,13 +93,13 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## mainLetters
 
-Removes vowel symbols from a Gurmukhi string.
+Removes vowel symbols from a Gurmukhi string
 
 **Parameters**
 
 -   `words` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The string from which to get main letters
-
--   `simplify` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to simplify half charactesr to full characters (eg. R to r)
+-   `simplify` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to simplify embedded vowels/nasal sounds (eg. E to a, ^ to K)
+-   `simplifyConsonants` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to simplify half characters to full characters (eg. R to r)
 
 **Examples**
 

--- a/src/__tests__/firstLetters.test.js
+++ b/src/__tests__/firstLetters.test.js
@@ -11,6 +11,31 @@ describe('firstLetters', () => {
       .toBe('sd');
   });
 
+  it('Should return first letters of each word and simplify ਖ਼ to ਖ', () => {
+    expect(firstLetters('^wlsw myro rUp hY ^ws ]'))
+      .toBe('KmrhK');
+  });
+
+  it('Should return first letters of each word and omit rahaao doojaa', () => {
+    expect(firstLetters('hukmu pCwix qw KsmY imlxw ]1] rhwau dUjw ]'))
+      .toBe('hpqKm');
+  });
+
+  it('Should return first letters of each word, simplify ਓ to ੳ and omit rahaao', () => {
+    expect(firstLetters('Ehw pRym iprI ]1] rhwau ]'))
+      .toBe('app');
+  });
+
+  it('Should return first letters of each word in gurmukhi unicode', () => {
+    expect(firstLetters('ਸਿਰ ਮਸ੍ਤਕ ਰਖੵਾ ਪਾਰਬ੍ਰਹਮੰ ਹਸ੍ਤ ਕਾਯਾ ਰਖੵਾ ਪਰਮੇਸ੍ਵਰਹ'))
+      .toBe('ਸਮਰਪਹਕਰਪ');
+  });
+
+  it('Should return first letters of each word in gurmukhi unicode and remove bindis', () => {
+    expect(firstLetters('ਬ ਗ਼ੁਫ਼ਤੰਦ ਖ਼ੁਸ਼ ਦੀਨ ਦਾਨਾਇ ਨਗ਼ਜ਼ ॥'))
+      .toBe('ਬਗਖਦਦਨ');
+  });
+
   it('Should return an empty string when no argument', () => {
     expect(firstLetters())
       .toBe('');

--- a/src/__tests__/firstLetters.test.js
+++ b/src/__tests__/firstLetters.test.js
@@ -12,7 +12,7 @@ describe('firstLetters', () => {
   });
 
   it('Should return first letters of each word and simplify ਖ਼ to ਖ', () => {
-    expect(firstLetters('^wlsw myro rUp hY ^ws ]'))
+    expect(firstLetters('^wlsw myro rUp hY ^ws ]', false, true))
       .toBe('KmrhK');
   });
 
@@ -21,8 +21,13 @@ describe('firstLetters', () => {
       .toBe('hpqKm');
   });
 
-  it('Should return first letters of each word, simplify ਓ to ੳ and omit rahaao', () => {
+  it('Should return first letters of each word and omit rahaao', () => {
     expect(firstLetters('Ehw pRym iprI ]1] rhwau ]'))
+      .toBe('Epp');
+  });
+
+  it('Should return first letters of each word, simplify ਓ to ੳ and omit rahaao', () => {
+    expect(firstLetters('Ehw pRym iprI ]1] rhwau ]', false, true))
       .toBe('app');
   });
 
@@ -31,8 +36,13 @@ describe('firstLetters', () => {
       .toBe('ਸਮਰਪਹਕਰਪ');
   });
 
-  it('Should return first letters of each word in gurmukhi unicode and remove bindis', () => {
+  it('Should return first letters of each word in gurmukhi unicode as is', () => {
     expect(firstLetters('ਬ ਗ਼ੁਫ਼ਤੰਦ ਖ਼ੁਸ਼ ਦੀਨ ਦਾਨਾਇ ਨਗ਼ਜ਼ ॥'))
+      .toBe('ਬਗ਼ਖ਼ਦਦਨ');
+  });
+
+  it('Should return first letters of each word in gurmukhi unicode and remove bindis', () => {
+    expect(firstLetters('ਬ ਗ਼ੁਫ਼ਤੰਦ ਖ਼ੁਸ਼ ਦੀਨ ਦਾਨਾਇ ਨਗ਼ਜ਼ ॥', false, true))
       .toBe('ਬਗਖਦਦਨ');
   });
 

--- a/src/__tests__/mainLetters.test.js
+++ b/src/__tests__/mainLetters.test.js
@@ -6,6 +6,31 @@ describe('mainLetters', () => {
       .toBe('Ae ml grsK Ae ml q mr gr k pAr');
   });
 
+  it('Should remove vowel symbols', () => {
+    expect(mainLetters('ik®s˜w qy jwnaU hir hir nwcMqI nwcnw ]1]'))
+      .toBe('ks q jna hr hr ncq ncn');
+  });
+
+  it('Should remove vowel symbols and simplify half consonants to their full counterparts', () => {
+    expect(mainLetters('ik®s˜w qy jwnaU hir hir nwcMqI nwcnw ]1]', true))
+      .toBe('krsn q jna hr hr ncq ncn');
+  });
+
+  it('Should remove vowel symbols', () => {
+    expect(mainLetters('isr msœk rK´w pwrbRhmM hsœ kwXw rK´w prmysÍrh ]'))
+      .toBe('sr msk rK prbhm hs kX rK prmsrh');
+  });
+
+  it('Should remove vowel symbols and simplify half consonants to their full counterparts', () => {
+    expect(mainLetters('isr msœk rK´w pwrbRhmM hsœ kwXw rK´w prmysÍrh ]', true))
+      .toBe('sr msqk rKX prbrhm hsq kX rKX prmsvrh');
+  });
+
+  it('Should remove vowel symbols and simplify half consonants to their full counterparts', () => {
+    expect(mainLetters('Ehw pRym iprI ]1] rhwau ', true))
+      .toBe('ah prm pr rha');
+  });
+
   it('Should return an empty string when no argument', () => {
     expect(mainLetters())
       .toBe('');

--- a/src/__tests__/mainLetters.test.js
+++ b/src/__tests__/mainLetters.test.js
@@ -12,7 +12,7 @@ describe('mainLetters', () => {
   });
 
   it('Should remove vowel symbols and simplify half consonants to their full counterparts', () => {
-    expect(mainLetters('ik®s˜w qy jwnaU hir hir nwcMqI nwcnw ]1]', true))
+    expect(mainLetters('ik®s˜w qy jwnaU hir hir nwcMqI nwcnw ]1]', true, true))
       .toBe('krsn q jna hr hr ncq ncn');
   });
 
@@ -22,12 +22,12 @@ describe('mainLetters', () => {
   });
 
   it('Should remove vowel symbols and simplify half consonants to their full counterparts', () => {
-    expect(mainLetters('isr msœk rK´w pwrbRhmM hsœ kwXw rK´w prmysÍrh ]', true))
+    expect(mainLetters('isr msœk rK´w pwrbRhmM hsœ kwXw rK´w prmysÍrh ]', false, true))
       .toBe('sr msqk rKX prbrhm hsq kX rKX prmsvrh');
   });
 
   it('Should remove vowel symbols and simplify half consonants to their full counterparts', () => {
-    expect(mainLetters('Ehw pRym iprI ]1] rhwau ', true))
+    expect(mainLetters('Ehw pRym iprI ]1] rhwau ', true, true))
       .toBe('ah prm pr rha');
   });
 

--- a/src/firstLetters.js
+++ b/src/firstLetters.js
@@ -11,13 +11,40 @@
  * // => 'AmgAmqmgkp'
  */
 
+const simplifications = [
+  ['E', 'a'],
+  ['ਓ', 'ੳ'],
+  ['L', 'l'],
+  ['ਲ਼', 'ਲ'],
+  ['S', 's'],
+  ['ਸ਼', 'ਸ'],
+  ['z', 'j'],
+  ['ਜ਼', 'ਜ'],
+  ['Z', 'g'],
+  ['ਗ਼', 'ਗ'],
+  ['\\^', 'K'],
+  ['ਖ਼', 'ਖ'],
+  ['ƒ', 'n'],
+  ['ਨੂੰ', 'ਨ'],
+  ['&', 'P'],
+  ['ਫ਼', 'ਫ'],
+];
+
 function firstLetters(words = '', eng = false) {
   if (words === '' || typeof words !== 'string') {
     return words;
   }
-  const newWords = words
+  let newWords = words;
+
+  simplifications.forEach((e) => {
+    newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
+  });
+  newWords = newWords
     .replace(/\]/g, '')
-    .replace(/rhwa/g, '')
+    .replace(/॥/g, '')
+    .replace(/।/g, '')
+    .replace(/rhwau dUjw/g, '')
+    .replace(/rhwau/g, '')
     .replace(/[0-9]/g, '');
 
   function firstLetter(word) {

--- a/src/firstLetters.js
+++ b/src/firstLetters.js
@@ -3,7 +3,8 @@
  *
  * @since 1.0.0
  * @param {string} words The string from which to get first letters
- * @param {boolean=} [eng=false] Whether the string is English
+ * @param {boolean} eng Whether the string is English (default=false)
+ * @param {boolean} simplify Whether to remove lagga matra/bindia (default=false)
  * @returns {string} Returns a single string of characters
  * @example
  *
@@ -30,15 +31,18 @@ const simplifications = [
   ['ਫ਼', 'ਫ'],
 ];
 
-function firstLetters(words = '', eng = false) {
+function firstLetters(words = '', eng = false, simplify = false) {
   if (words === '' || typeof words !== 'string') {
     return words;
   }
   let newWords = words;
 
-  simplifications.forEach((e) => {
-    newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
-  });
+  if (simplify) {
+    simplifications.forEach((e) => {
+      newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
+    });
+  }
+
   newWords = newWords
     .replace(/\]/g, '')
     .replace(/॥/g, '')

--- a/src/mainLetters.js
+++ b/src/mainLetters.js
@@ -3,6 +3,7 @@
  *
  * @since 1.0.0
  * @param {string} words The string from which to get main letters
+ * @param {boolean} simplify Whether to simplify half-chars
  * @returns {string} Returns a single string of characters
  * @example
  *
@@ -15,7 +16,7 @@ const simplifications1 = [
   ['L', 'l'],
   ['S', 's'],
   ['z', 'j'],
-  ['Z', 'G'],
+  ['Z', 'g'],
   ['\\^', 'K'],
   ['ƒ', 'n'],
   ['&', 'P'],
@@ -27,6 +28,8 @@ const simplifications2 = [
   ['®', 'r'],
   ['Í', 'v'],
   ['œ', 'q'],
+  ['ç', 'c'],
+  ['†', 't'],
   ['˜', 'n'],
   ['´', 'X'],
   ['Î', 'X'],

--- a/src/mainLetters.js
+++ b/src/mainLetters.js
@@ -3,7 +3,8 @@
  *
  * @since 1.0.0
  * @param {string} words The string from which to get main letters
- * @param {boolean} simplify Whether to simplify half-chars
+ * @param {boolean} simplify Whether to remove lagga matra/bindia (default=false)
+ * @param {boolean} simplifyConsonants Whether to simplify half-chars (default=false)
  * @returns {string} Returns a single string of characters
  * @example
  *
@@ -11,6 +12,7 @@
  * // => 'Ae ml grsK Ae ml q mr gr k pAr'
  */
 
+// remove embedded lagga matra and bindia
 const simplifications1 = [
   ['E', 'a'],
   ['L', 'l'],
@@ -22,6 +24,7 @@ const simplifications1 = [
   ['&', 'P'],
 ];
 
+// transform half-letters to full letters
 const simplifications2 = [
   ['H', 'h'],
   ['R', 'r'],
@@ -37,20 +40,20 @@ const simplifications2 = [
   ['í', 'X'],
 ];
 
-function mainLetters(words = '', simplify = false) {
+function mainLetters(words = '', simplify = false, simplifyConsonants = false) {
   if (words === '' || typeof words !== 'string') {
     return words;
   }
 
   let newWords = words;
 
-  // remove embedded lagga matra and bindia
-  simplifications1.forEach((e) => {
-    newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
-  });
-
-  // optionally transform half-letters to full letters
   if (simplify) {
+    simplifications1.forEach((e) => {
+      newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
+    });
+  }
+
+  if (simplifyConsonants) {
     simplifications2.forEach((e) => {
       newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
     });

--- a/src/mainLetters.js
+++ b/src/mainLetters.js
@@ -10,13 +10,55 @@
  * // => 'Ae ml grsK Ae ml q mr gr k pAr'
  */
 
-function mainLetters(words = '') {
+const simplifications1 = [
+  ['E', 'a'],
+  ['L', 'l'],
+  ['S', 's'],
+  ['z', 'j'],
+  ['Z', 'G'],
+  ['\\^', 'K'],
+  ['ƒ', 'n'],
+  ['&', 'P'],
+];
+
+const simplifications2 = [
+  ['H', 'h'],
+  ['R', 'r'],
+  ['®', 'r'],
+  ['Í', 'v'],
+  ['œ', 'q'],
+  ['˜', 'n'],
+  ['´', 'X'],
+  ['Î', 'X'],
+  ['ì', 'X'],
+  ['í', 'X'],
+];
+
+function mainLetters(words = '', simplify = false) {
   if (words === '' || typeof words !== 'string') {
     return words;
   }
-  return words
+
+  let newWords = words;
+
+  // remove embedded lagga matra and bindia
+  simplifications1.forEach((e) => {
+    newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
+  });
+
+  // optionally transform half-letters to full letters
+  if (simplify) {
+    simplifications2.forEach((e) => {
+      newWords = newWords.replace(new RegExp(e[0], 'g'), e[1]);
+    });
+  } else {
+    newWords = newWords.replace(/[HR]/g, '');
+  }
+
+  return newWords
     .replace(/[^A-Za-z ]/g, '')
-    .replace(/[uUiIyYwWoOMNØRH@~®`]/g, '')
+    .replace(/[uUiIyYwWoOMN]/g, '')
+    .replace(/[ \s]+/g, ' ')
     .trim();
 }
 


### PR DESCRIPTION
Simplifies ਓ to ੳ, ਖ਼ to ਖ, etc. for firstLetter and mainLetter.

Optionally, simplify half chars to full chars for mainLetter (R to r, etc.) by passing in simplify=true.