### PR TITLE
ignore vishraam chars in firstLetters

### DIFF
--- a/src/__tests__/firstLetters.test.js
+++ b/src/__tests__/firstLetters.test.js
@@ -60,6 +60,12 @@ describe('firstLetters', () => {
     expect(firstLetters('|| jap ||', true))
       .toBe('j');
   });
+
+  it('Should return first letters of each word, excluding vishraam chars (;,.)', () => {
+    expect(firstLetters('rwgu bsµqu, mhlw 1; Gru 1, caupdy; duquky', true))
+      .toBe('rbmGcd');
+  });
+
   it('Should return an empty string when no argument', () => {
     expect(firstLetters())
       .toBe('');

--- a/src/firstLetters.js
+++ b/src/firstLetters.js
@@ -50,7 +50,8 @@ function firstLetters(words = '', eng = false, simplify = false) {
     .replace(/।/g, '')
     .replace(/rhwau dUjw/g, '')
     .replace(/rhwau/g, '')
-    .replace(/[0-9]/g, '');
+    .replace(/[0-9]/g, '')
+    .replace(/[;,.]/g, '');
 
   function firstLetter(word) {
     if (word) {


### PR DESCRIPTION
I came across this issue when trying to search for a Sirlekh yesterday. Since we are ignore numbers, we end up with `firstLetters` that contain vishram characters (`;`, `,`, `.`), so I decided to ignore those as well.

### Example

|  | Value |
|---|---|
| Pangti | ਰਾਗੁ ਬਸੰਤੁ, ਮਹਲਾ ੧; ਘਰੁ ੧, ਚਉਪਦੇ; ਦੁਤੁਕੇ |
| Usage | `firstLetters('rwgu bsµqu, mhlw 1; Gru 1, caupdy; duquky')` |
| Previous result | `"rbm;G,cd"` |
| New result | `"rbmGcd"` |