### PR TITLE
Updated ASCII to Unicode edgecases with Yakash + Aunkar/Dulainkar

### DIFF
--- a/src/__tests__/unicode.test.js
+++ b/src/__tests__/unicode.test.js
@@ -370,8 +370,11 @@ describe('unicodereverse', () => {
     expect(unicode('ਕਵਨੁ ਜੋਗੁ ਕਉਨੁ ਗੵਾਨੁ ਧੵਾਨੁ ਕਵਨ ਬਿਧਿ ਉਸ੍ਤਤਿ ਕਰੀਐ ॥', true))
       .toBe('kvnu jogu kaunu g´wnu D´wnu kvn ibiD ausœiq krIAY ]');
 
-    /* expect(unicode('ਲੈ ਅਕ੍ਰੂਰ ਕਉ ਆਪਨੇ ਸੰਗ ਕਹਿਯੋ ਅਰੇ ਕਾਨ੍ਰਹ ਕਹੰŧ ਕਉ ਪਧਾਰਿਯੋ ॥', true))
-      .toBe('lY AkR¨r kau Awpny sMg kihXo Ary kwnRh khMŧ kau pDwirXo ]'); */
+    expect(unicode('ਲੈ ਅਕ੍ਰੂਰ ਕਉ ਆਪਨੇ ਸੰਗ ਕਹਿਯੋ ਅਰੇ ਕਾਨ੍ਰਹ ਕਹੰŧ ਕਉ ਪਧਾਰਿਯੋ ॥', true))
+      .toBe('lY AkR¨r kau Awpny sMg kihXo Ary kwnRh khMŧ kau pDwirXo ]');
+
+    expect(unicode('ਮ੍ਰਿਤੵੁ ਜਨਮ ਭ੍ਰਮੰਤਿ ਨਰਕਹ; ਅਨਿਕ ਉਪਾਵੰ, ਨ ਸਿਧੵਤੇ ॥', true))
+      .toBe('imRq´ü jnm BRmMiq nrkh; Aink aupwvM, n isD´qy ]');
 
     expect(unicode('ਸਲੋਕ ਮਃ ੩ ॥', true))
       .toBe('slok mÚ 3 ]');

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -332,7 +332,7 @@ function ascii(text = '', simplify = false) {
         j += 1;
       }
       j += 1;
-    } else if (currentChar === 'ੑ') {
+    } else if (currentChar === 'ੑ' || currentChar === 'ੵ') {
       convertedText.push(reverseMapping[currentChar] || currentChar);
       if (nextChar === 'ੁ') {
         convertedText.push('ü');


### PR DESCRIPTION
When converting ASCII to unicode, the character for aunkar/dulainkar should be ü/¨ when preceeded by either a halant + akhar, udaat, or yakash. This allows GurbaniAkhar to place the aunkar/dulainkar lower so it isn't obstructing the preceeding character.

Ex: `ਮ੍ਰਿਤੵੁ` should convert to `imRq´ü` which renders as  <img width="63" alt="Screenshot 2024-07-16 at 10 15 40 AM" src="https://github.com/user-attachments/assets/18c8f07f-4272-48a0-a6e1-737ae14686fa">

The code currently only handles halant+akhar and udaat ( ੑ )