### PR TITLE
Update Webpack config for compatability with NodeJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,11 @@ module.exports = {
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'dist'),
-    library: 'anvaad-js',
-    libraryTarget: 'umd',
+    library: {
+      name: 'anvaad-js',
+      type: 'umd',
+    },
+    globalObject: 'this',
   },
   module: {
     rules: [


### PR DESCRIPTION
The latest version of the package wasn't working in some node environments without using a polyfill.

This change explicitly sets globalObject for compatibility with browsers and node (see [docs](https://webpack.js.org/configuration/output/#outputglobalobject)), and updates the older deprecated syntax.